### PR TITLE
feat: implement screenshot service and integrate with test reporter

### DIFF
--- a/SeleniumTraining/Core/Services/Contracts/IScreenshotService.cs
+++ b/SeleniumTraining/Core/Services/Contracts/IScreenshotService.cs
@@ -1,0 +1,32 @@
+namespace SeleniumTraining.Core.Services.Contracts;
+
+/// <summary>
+/// Defines the contract for a service responsible for capturing and saving screenshots from a WebDriver instance.
+/// </summary>
+/// <remarks>
+/// Implementations of this interface will handle the technical details of interacting with the WebDriver
+/// to get screenshot data and persisting it to the file system. This service decouples screenshot
+/// functionality from other services that might need to consume or trigger screenshots (e.g., reporting services).
+/// </remarks>
+public interface IScreenshotService
+{
+    /// <summary>
+    /// Captures a screenshot from the provided WebDriver instance and saves it to the specified directory with the given file name.
+    /// </summary>
+    /// <param name="driver">The <see cref="IWebDriver"/> instance from which to take the screenshot. Must implement <see cref="ITakesScreenshot"/>.</param>
+    /// <param name="directory">The directory where the screenshot image file will be saved. This directory will be created if it doesn't exist.</param>
+    /// <param name="fileNameWithoutExtension">The desired file name for the screenshot. The ".png" extension will be appended automatically.</param>
+    /// <returns>The full path to the saved screenshot file if successful; otherwise, <c>null</c> if capture or saving fails (e.g., driver doesn't support screenshots, I/O errors).</returns>
+    /// <remarks>
+    /// This method is responsible for:
+    /// <list type="bullet">
+    ///   <item><description>Verifying that the driver can take screenshots.</description></item>
+    ///   <item><description>Capturing the screenshot data.</description></item>
+    ///   <item><description>Ensuring the target directory exists.</description></item>
+    ///   <item><description>Saving the screenshot as a PNG file.</description></item>
+    /// </list>
+    /// Any exceptions during the process should be handled internally by the implementation, typically resulting in a <c>null</c> return value and logged errors.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">May be thrown by implementations if <paramref name="driver"/>, <paramref name="directory"/>, or <paramref name="fileNameWithoutExtension"/> is null or invalid, though implementations are encouraged to handle gracefully and return null.</exception>
+    public string? CaptureAndSaveScreenshot(IWebDriver driver, string directory, string fileNameWithoutExtension);
+}

--- a/SeleniumTraining/Core/Services/Contracts/ITestReporterService.cs
+++ b/SeleniumTraining/Core/Services/Contracts/ITestReporterService.cs
@@ -6,7 +6,8 @@ namespace SeleniumTraining.Core.Services.Contracts;
 /// </summary>
 /// <remarks>
 /// This service encapsulates the logic for setting up report metadata at the beginning
-/// of a test and capturing relevant information (like screenshots on failure) at the end.
+/// of a test and capturing relevant information (like test outcomes and attaching
+/// pre-captured artifacts like screenshots on failure) at the end.
 /// It helps in generating comprehensive and informative test execution reports.
 /// </remarks>
 public interface ITestReporterService
@@ -33,16 +34,18 @@ public interface ITestReporterService
     /// </summary>
     /// <param name="testContext">The NUnit <see cref="TestContext"/> for the current test, providing access to test results and metadata.</param>
     /// <param name="driver">The <see cref="IWebDriver"/> instance used in the test. Can be null if the driver failed to initialize or was already quit.
-    /// Used for taking screenshots on failure.</param>
+    /// This is passed to facilitate potential interactions if still needed, though primary screenshot capture is now delegated.</param>
     /// <param name="browserType">The <see cref="BrowserType"/> on which the test was executed. Used for report categorization.</param>
-    /// <param name="screenshotDirectory">The directory where screenshots (e.g., on failure) should be saved.
-    /// This path is then typically used for attaching screenshots to the report.</param>
+    /// <param name="screenshotDirectory">The directory where screenshots (e.g., on failure, captured by another service) are located or should be organized.
+    /// This path is then typically used for retrieving screenshots for attachment to the report.</param>
     /// <param name="correlationId">The unique correlation ID for the test execution, used to link report entries with logs.</param>
     /// <remarks>
     /// This method is responsible for actions like:
     /// <list type="bullet">
     ///   <item><description>Determining the test status (pass/fail/skipped).</description></item>
-    ///   <item><description>Taking and attaching screenshots if the test failed (if a driver instance is available).</description></item>
+    ///   <item><description>If the test failed and a WebDriver instance is available, it coordinates with an <see cref="IScreenshotService"/> (or similar)
+    ///   to capture and save a screenshot. The path to this screenshot is then used for attachments.</description></item>
+    ///   <item><description>Attaching screenshots (if captured) to NUnit and Allure reports.</description></item>
     ///   <item><description>Adding any final environment details or test outcome information to the report.</description></item>
     /// </list>
     /// </remarks>

--- a/SeleniumTraining/Core/Services/ScreenshotService.cs
+++ b/SeleniumTraining/Core/Services/ScreenshotService.cs
@@ -1,0 +1,65 @@
+namespace SeleniumTraining.Core.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IScreenshotService"/> for capturing and saving screenshots
+/// from WebDriver instances.
+/// </summary>
+/// <remarks>
+/// This service inherits from <see cref="BaseService"/> to leverage common logging functionalities.
+/// It handles the conversion of WebDriver's screenshot data into a PNG file and saves it to the specified location.
+/// Error handling is included to manage issues during screenshot capture or file I/O, with errors being logged.
+/// </remarks>
+public class ScreenshotService : BaseService, IScreenshotService
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenshotService"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">The logger factory, passed to the base <see cref="BaseService"/> for creating loggers. Must not be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="loggerFactory"/> is null.</exception>
+    public ScreenshotService(ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        ServiceLogger.LogInformation("{ServiceName} initialized.", nameof(ScreenshotService));
+    }
+
+    /// <inheritdoc cref="IScreenshotService.CaptureAndSaveScreenshot(IWebDriver, string, string)"/>
+    /// <remarks>
+    /// This implementation first checks if the provided <paramref name="driver"/> can take screenshots.
+    /// It then constructs the full file path, ensures the target directory exists,
+    /// captures the screenshot, and saves it as a PNG file.
+    /// Exceptions encountered during these operations are logged, and the method returns <c>null</c> in case of failure.
+    /// </remarks>
+    public string? CaptureAndSaveScreenshot(IWebDriver driver, string directory, string fileNameWithoutExtension)
+    {
+        if (driver is not ITakesScreenshot screenshotDriver)
+        {
+            ServiceLogger.LogWarning("WebDriver instance does not support ITakesScreenshot. Cannot capture screenshot.");
+            return null;
+        }
+
+        string filePath = Path.Combine(directory, $"{fileNameWithoutExtension}.png");
+
+        try
+        {
+            ServiceLogger.LogDebug("Attempting to capture screenshot. Target path: {FilePath}", filePath);
+            Screenshot screenshot = screenshotDriver.GetScreenshot();
+
+            string? targetDirectoryPath = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrEmpty(targetDirectoryPath))
+            {
+                ServiceLogger.LogError("Could not determine directory from path {FilePath}. Screenshot saving aborted.", filePath);
+                return null;
+            }
+            _ = Directory.CreateDirectory(targetDirectoryPath);
+
+            screenshot.SaveAsFile(filePath);
+            ServiceLogger.LogInformation("Screenshot successfully saved to {FilePath}", filePath);
+            return filePath;
+        }
+        catch (Exception ex)
+        {
+            ServiceLogger.LogError(ex, "Failed to capture or save screenshot to {FilePath}.", filePath);
+            return null;
+        }
+    }
+}
+

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Data.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Data.cs
@@ -27,8 +27,7 @@ public partial class SauceDemoTests : BaseTest
     ///   <item><description>Sort by Value: "az", "za", "lohi", "hilo"</description></item>
     /// </list>
     /// </remarks>
-    private readonly List<KeyValuePair<SortByType, string>> _inventoryProductsDropdownOptions =
-    [
+    private readonly List<KeyValuePair<SortByType, string>> _inventoryProductsDropdownOptions = [
         new(SortByType.Text, "Name (A to Z)"),
         new(SortByType.Text, "Name (Z to A)"),
         new(SortByType.Text, "Price (low to high)"),

--- a/SeleniumTraining/Utils/Extensions/ServiceCollectionExtensions.cs
+++ b/SeleniumTraining/Utils/Extensions/ServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IDriverLifecycleService, DriverLifecycleService>()
             .AddScoped<ITestWebDriverManager, TestWebDriverManager>()
             .AddTransient<ITestReporterService, TestReporterService>()
+            .AddTransient<IScreenshotService, ScreenshotService>()
             .AddScoped<IVisualTestService, VisualTestService>()
             .AddSingleton<IRetryService, RetryService>();
 


### PR DESCRIPTION
This commit introduces a screenshot service and integrates it with the test reporter to capture and attach screenshots on test failures. This enhances the reporting capabilities by providing visual evidence of failures.

- Added `IScreenshotService` interface and `ScreenshotService` implementation for capturing and saving screenshots.
- Registered `IScreenshotService` in `ServiceCollectionExtensions`.
- Modified `ITestReporterService` and `TestReporterService` to utilize `IScreenshotService` for capturing screenshots on failure.
- Updated `TestReporterService` to attach screenshots to NUnit and Allure reports using the captured screenshot file path.
- Updated `SauceDemoTests.Data.cs` to use collection initializer syntax.
- Updated `ITestReporterService` xml documentation to reflect changes.