### PR TITLE
feat: implement element caching in base page and component classes

### DIFF
--- a/SeleniumTraining/Pages/SauceDemo/Components/BasePageComponent.cs
+++ b/SeleniumTraining/Pages/SauceDemo/Components/BasePageComponent.cs
@@ -4,18 +4,27 @@ namespace SeleniumTraining.Pages.SauceDemo.Components;
 /// Provides a foundational abstract class for Page Components within the Selenium test automation framework.
 /// Page Components represent reusable, isolated parts of a web page (e.g., a product card, a search widget).
 /// This base class encapsulates common functionalities such as a root element context,
-/// WebDriver and WebDriverWait instances, logging, settings access, and retry mechanisms.
+/// WebDriver and WebDriverWait instances, logging, settings access, retry mechanisms, and
+/// an element caching strategy to improve performance by reducing redundant element lookups.
 /// </summary>
 /// <remarks>
 /// Derived Page Component classes are typically initialized with a specific <see cref="RootElement"/>
 /// which scopes their interactions to that part of the DOM. This promotes encapsulation and reusability.
 /// It provides helper methods like <see cref="FindElement(By)"/> to locate sub-elements relative
-/// to the component's <see cref="RootElement"/>, and <see cref="HighlightIfEnabled(IWebElement)"/>
-/// for debugging. Access to shared services like <see cref="IRetryService"/> and
-/// <see cref="TestFrameworkSettings"/> is also provided.
+/// to the component's <see cref="RootElement"/>, which now includes caching with stale element checks.
+/// It also offers <see cref="HighlightIfEnabled(IWebElement)"/> for debugging.
+/// Access to shared services like <see cref="IRetryService"/> and
+/// <see cref="TestFrameworkSettings"/> is also provided. The element cache (<see cref="_elementCache"/>)
+/// is instance-based and stores elements found within this component.
 /// </remarks>
 public abstract class BasePageComponent
 {
+    /// <summary>
+    /// Instance-level cache for storing <see cref="IWebElement"/> instances found within this component,
+    /// keyed by their <see cref="By"/> locator. This helps to reduce redundant DOM lookups.
+    /// </summary>
+    private readonly Dictionary<By, IWebElement> _elementCache = [];
+
     /// <summary>
     /// Gets the root <see cref="IWebElement"/> that defines the scope of this page component.
     /// All element searches within the component are typically relative to this root.
@@ -100,19 +109,48 @@ public abstract class BasePageComponent
 
     /// <summary>
     /// Finds a sub-element within this component, starting the search from the component's <see cref="RootElement"/>.
+    /// This method incorporates an element caching strategy: if an element for the given <paramref name="locator"/>
+    /// is found in the cache and is not stale, it is returned directly. Otherwise, the element is located
+    /// from the <see cref="RootElement"/>, stored in the cache, and then returned.
     /// </summary>
     /// <param name="locator">The <see cref="By"/> locator strategy to find the sub-element.</param>
     /// <returns>The <see cref="IWebElement"/> representing the found sub-element.</returns>
-    /// <exception cref="NoSuchElementException">Thrown if no element is found using the provided <paramref name="locator"/> within the component's scope.</exception>
+    /// <exception cref="NoSuchElementException">Thrown if no element is found using the provided <paramref name="locator"/> within the component's scope after a cache miss or if the cached element was stale and re-fetch failed.</exception>
     /// <remarks>
     /// This method scopes the search to within the component's defined <see cref="RootElement"/>,
-    /// promoting encapsulation and preventing unintended selection of elements outside the component.
-    /// The search operation is logged.
+    /// promoting encapsulation. The caching mechanism helps reduce redundant DOM lookups for frequently accessed elements.
+    /// Stale element checks are performed on cached elements before returning them.
+    /// The search and caching operations are logged.
     /// </remarks>
     protected IWebElement FindElement(By locator)
     {
-        ComponentLogger.LogDebug("Component {ComponentName} finding sub-element: {Locator}", GetType().Name, locator);
-        return RootElement.FindElement(locator);
+        ComponentLogger.LogTrace("Component {ComponentName} attempting to find sub-element: {Locator}", GetType().Name, locator);
+
+        if (_elementCache.TryGetValue(locator, out IWebElement? cachedElement))
+        {
+            try
+            {
+                _ = cachedElement.Enabled;
+                ComponentLogger.LogTrace("Returning element for locator '{Locator}' from component cache.", locator);
+                return cachedElement;
+            }
+            catch (StaleElementReferenceException)
+            {
+                ComponentLogger.LogDebug("Cached element for locator '{Locator}' in component '{ComponentName}' was stale. Removing from cache.", locator, GetType().Name);
+                _ = _elementCache.Remove(locator);
+            }
+            catch (Exception ex)
+            {
+                ComponentLogger.LogWarning(ex, "Unexpected error checking staleness of cached element for locator '{Locator}' in component '{ComponentName}'. Will re-fetch.", locator, GetType().Name);
+                _ = _elementCache.Remove(locator);
+            }
+        }
+
+        ComponentLogger.LogTrace("Element for locator '{Locator}' not in component cache or was stale. Finding new element.", locator);
+        IWebElement newElement = RootElement.FindElement(locator);
+        _elementCache[locator] = newElement; // Add or update in cache
+        ComponentLogger.LogDebug("Found and cached new element for locator '{Locator}' in component '{ComponentName}'.", locator, GetType().Name);
+        return newElement;
     }
 
     /// <summary>
@@ -132,5 +170,16 @@ public abstract class BasePageComponent
             _ = element.HighlightElement(Driver, ComponentLogger, FrameworkSettings.HighlightDurationMs);
 
         return element;
+    }
+
+    /// <summary>
+    /// Clears the internal element cache for this component instance.
+    /// This should be called if actions performed within the component are known to
+    /// drastically alter its internal DOM structure, potentially making all cached elements stale.
+    /// </summary>
+    protected void ClearComponentElementCache()
+    {
+        ComponentLogger.LogDebug("Clearing element cache for component {ComponentName}.", GetType().Name);
+        _elementCache.Clear();
     }
 }


### PR DESCRIPTION
This commit introduces element caching to the `BasePage` and `BasePageComponent` classes to improve performance by reducing redundant DOM lookups.

- Implemented element caching in `BasePageComponent` using a dictionary (`_elementCache`) to store `IWebElement` instances keyed by their `By` locator. The `FindElement` method now checks the cache for existing elements and performs stale element checks before returning them. A `ClearComponentElementCache` method was added to clear the cache when the DOM structure changes significantly.
- Implemented element caching in `BasePage` using a dictionary (`_pageElementCache`) to store `IWebElement` instances keyed by their `By` locator. The `FindElementOnPage` method now checks the cache for existing elements and performs stale element checks before returning them. A `ClearPageElementCache` method was added to clear the cache when the DOM structure changes significantly.
- Updated documentation in both `BasePage` and `BasePageComponent` to reflect the new caching mechanism.
- Modified `InventoryPage` to utilize the `FindElementOnPage` method for locating elements, leveraging the page-level caching. Updated documentation and comments to reflect the usage of caching.