### PR TITLE
feat: add user profile preferences to browser settings

### DIFF
--- a/SeleniumTraining/Core/Services/Drivers/ChromiumDriverFactoryServiceBase.cs
+++ b/SeleniumTraining/Core/Services/Drivers/ChromiumDriverFactoryServiceBase.cs
@@ -104,6 +104,31 @@ public abstract class ChromiumDriverFactoryServiceBase : DriverFactoryServiceBas
                 }
             }
         }
+
+        if (settings.UserProfilePreferences != null && settings.UserProfilePreferences.Count > 0)
+        {
+            ServiceLogger.LogDebug(
+                "Applying {PrefCount} user profile preferences for {BrowserType}.",
+                settings.UserProfilePreferences.Count,
+                ConcreteBrowserType
+            );
+
+            foreach (KeyValuePair<string, object> pref in settings.UserProfilePreferences)
+            {
+                try
+                {
+                    chromeOptions.AddUserProfilePreference(pref.Key, pref.Value);
+                    appliedOptionsForLog.Add($"pref:{pref.Key}={pref.Value}");
+
+                    ServiceLogger.LogTrace("Applied user profile preference for {BrowserType}: '{PrefKey}' = '{PrefValue}'", ConcreteBrowserType, pref.Key, pref.Value);
+                }
+                catch (Exception ex)
+                {
+                    ServiceLogger.LogError(ex, "Failed to apply user profile preference '{PrefKey}' with value '{PrefValue}' for {BrowserType}.", pref.Key, pref.Value, ConcreteBrowserType);
+                }
+            }
+        }
+
         return chromeOptions;
     }
 

--- a/SeleniumTraining/Utils/Settings/BrowserSettings/ChromiumBasedSettings.cs
+++ b/SeleniumTraining/Utils/Settings/BrowserSettings/ChromiumBasedSettings.cs
@@ -46,4 +46,15 @@ public class ChromiumBasedSettings : BaseBrowserSettings
     /// Arguments should be provided in the format expected by the browser executable.
     /// </remarks>
     public List<string> ChromeArguments { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a dictionary of user profile preferences to apply to the browser session.
+    /// Keys are preference names (e.g., "credentials_enable_service"), and values are the preference values.
+    /// </summary>
+    /// <value>A dictionary of user profile preferences. Defaults to an empty dictionary.</value>
+    /// <remarks>
+    /// This allows for fine-grained control over browser features, such as disabling the password manager.
+    /// Example: {"profile.password_manager_enabled": false, "credentials_enable_service": false }
+    /// </remarks>
+    public Dictionary<string, object> UserProfilePreferences { get; set; } = [];
 }

--- a/SeleniumTraining/appsettings.json
+++ b/SeleniumTraining/appsettings.json
@@ -53,9 +53,21 @@
     "WindowHeight": 1080,
     "ChromeHeadlessArgument": "--headless=new",
     "ChromeArguments": [
-      "--disable-gpu"
+      "--disable-gpu",
+      "--password-store=basic",
+      "--disable-features=PasswordManager",
+      "--disable-infobars"
     ],
-    "LeaveBrowserOpenAfterTest": false
+    "LeaveBrowserOpenAfterTest": false,
+    "UserProfilePreferences": {
+      "credentials_enable_service": false,
+      "profile.password_manager_enabled": false,
+      "profile.default_content_setting_values.password_protection": 2,
+      "profile.password_manager_leak_detection_enabled": false,
+      "autofill.profile_enabled": false,
+      "autofill.credit_card_enabled": false,
+      "profile.default_content_settings.popups": 2
+    }
   },
   "BraveBrowserOptions": {
     "Headless": false,


### PR DESCRIPTION
This commit introduces the ability to configure user profile preferences for Chromium-based browsers, allowing for customization of browser behavior such as disabling password management and autofill features.

- Added `UserProfilePreferences` dictionary to `ChromiumBasedSettings` to store user profile preferences.
- Implemented logic in `ChromiumDriverFactoryServiceBase` to apply these preferences to ChromeOptions.
- Added corresponding configuration in `appsettings.json` to disable password management, autofill, and popups.