### PR TITLE
feat: integrate WebDriverManager for driver management

### DIFF
--- a/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
@@ -1,6 +1,8 @@
 using System.Runtime.InteropServices;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
+using WebDriverManager;
+using WebDriverManager.DriverConfigs.Impl;
 
 namespace SeleniumTraining.Core.Services.Drivers;
 
@@ -108,9 +110,19 @@ public class ChromeDriverFactoryService : ChromiumDriverFactoryServiceBase, IBro
     }
 
     /// <inheritdoc cref="IBrowserDriverFactoryService.CreateDriver(BaseBrowserSettings, DriverOptions)" />
+    /// <summary>
+    /// Creates and configures a WebDriver instance for Chrome, supporting both local and remote (Selenium Grid) execution.
+    /// </summary>
     /// <remarks>
-    /// If a <see cref="BaseBrowserSettings.SeleniumGridUrl"/> is provided in the settings, this method creates a
-    /// <see cref="RemoteWebDriver"/> instance targeting the grid. Otherwise, it creates a local <see cref="ChromeDriver"/> instance.
+    /// This method orchestrates the creation of a Chrome WebDriver by following these steps:
+    /// <list type="number">
+    ///   <item><description>Validates that the provided settings are of type <see cref="ChromeSettings"/>.</description></item>
+    ///   <item><description>Configures <see cref="ChromeOptions"/> with common settings (headless, window size, etc.) and any custom arguments.</description></item>
+    ///   <item><description>Checks if a <see cref="BaseBrowserSettings.SeleniumGridUrl"/> is specified in the settings.</description></item>
+    ///   <item><description><b>If a Grid URL is present</b>, it creates a <see cref="RemoteWebDriver"/> instance pointing to the grid.</description></item>
+    ///   <item><description><b>If no Grid URL is present</b>, it uses <see cref="WebDriverManager"/> to set up the local `chromedriver.exe` and then creates a local <see cref="ChromeDriver"/> instance.</description></item>
+    ///   <item><description>Performs a browser version check against the minimum supported version.</description></item>
+    /// </list>
     /// </remarks>
     public IWebDriver CreateDriver(BaseBrowserSettings settingsBase, DriverOptions? options = null)
     {
@@ -132,39 +144,13 @@ public class ChromeDriverFactoryService : ChromiumDriverFactoryServiceBase, IBro
             settings.WindowHeight ?? -1
         );
 
-        string chromeExecutablePath = GetChromeExecutablePathInternal();
-
-        if (string.IsNullOrEmpty(chromeExecutablePath))
-        {
-            ServiceLogger.LogWarning("Chrome executable path not found. WebDriverManager will use default detection if possible, and Selenium will rely on PATH.");
-        }
-        else
-        {
-            ServiceLogger.LogInformation("Chrome executable path determined to be: {ChromePath}", chromeExecutablePath);
-        }
-
-        // try
-        // {
-        //     Logger.LogInformation("Attempting to set up ChromeDriver using WebDriverManager's default behavior for ChromeConfig (will attempt auto-detection).");
-        //     _ = new DriverManager().SetUpDriver(new ChromeConfig());
-        //     Logger.LogInformation("WebDriverManager successfully completed default ChromeDriver setup for Chrome.");
-        // }
-        // catch (Exception ex)
-        // {
-        //     Logger.LogError(ex, "WebDriverManager failed to set up ChromeDriver using default ChromeConfig.");
-        //     throw;
-        // }
-
         ChromeOptions chromeOptions = ConfigureCommonChromeOptions(settings, options, out List<string> appliedOptionsForLog);
 
+        string chromeExecutablePath = GetChromeExecutablePathInternal();
         if (!string.IsNullOrEmpty(chromeExecutablePath) && File.Exists(chromeExecutablePath))
-        {
             chromeOptions.BinaryLocation = chromeExecutablePath;
-        }
         else
-        {
             ServiceLogger.LogDebug("Chrome binary location not explicitly set in options; Selenium will use default system path or detected driver's expectation.");
-        }
 
         ServiceLogger.LogInformation(
             "ChromeOptions configured for {BrowserType}. BinaryLocation: {BinaryLocation}. Effective arguments: [{EffectiveArgs}]",
@@ -176,16 +162,26 @@ public class ChromeDriverFactoryService : ChromiumDriverFactoryServiceBase, IBro
         if (string.IsNullOrEmpty(settings.SeleniumGridUrl))
         {
             ServiceLogger.LogInformation("Creating local ChromeDriver instance.");
-            
+
+            ServiceLogger.LogDebug("Attempting to set up ChromeDriver using WebDriverManager (ChromeConfig).");
+            try
+            {
+                _ = new DriverManager().SetUpDriver(new ChromeConfig());
+                ServiceLogger.LogInformation("WebDriverManager successfully completed ChromeDriver setup (ChromeConfig).");
+            }
+            catch (Exception ex)
+            {
+                ServiceLogger.LogError(ex, "WebDriverManager failed to set up ChromeDriver (ChromeConfig).");
+                throw;
+            }
+
             return CreateDriverInstanceWithChecks(chromeOptions);
         }
         else
         {
             ServiceLogger.LogInformation("Creating RemoteWebDriver instance for Chrome Grid at {GridUrl}", settings.SeleniumGridUrl);
-
             var remoteDriver = new RemoteWebDriver(new Uri(settings.SeleniumGridUrl), chromeOptions);
             PerformVersionCheck(remoteDriver, Type.ToString(), MinimumSupportedVersion);
-
             return remoteDriver;
         }
     }

--- a/SeleniumTraining/SeleniumTraining.csproj
+++ b/SeleniumTraining/SeleniumTraining.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="Selenium.Support" Version="4.33.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.33.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="136.0.7103.4900" />
     <PackageReference Include="SeleniumExtras.WaitHelpers" Version="1.0.2" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />


### PR DESCRIPTION
This commit integrates WebDriverManager to handle browser driver setup, removing the need for explicit ChromeDriver installation. This simplifies the project setup and ensures compatibility across different environments.

Changes include:

- Removed the `Selenium.WebDriver.ChromeDriver` NuGet package.
- Integrated WebDriverManager into `ChromeDriverFactoryService` to automatically manage ChromeDriver versions and setup.
- Modified the driver factory services to use WebDriverManager to set up the drivers before creating the driver instances.
- Updated logging to reflect WebDriverManager's activities.