### PR TITLE
feat: remove WebDriverManager and rely on Selenium Manager

### DIFF
--- a/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
@@ -1,8 +1,6 @@
 using System.Runtime.InteropServices;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
-using WebDriverManager;
-using WebDriverManager.DriverConfigs.Impl;
 
 namespace SeleniumTraining.Core.Services.Drivers;
 
@@ -93,11 +91,12 @@ public class ChromeDriverFactoryService : ChromiumDriverFactoryServiceBase
 
         if (string.IsNullOrEmpty(settings.SeleniumGridUrl))
         {
-            _ = new DriverManager().SetUpDriver(new ChromeConfig());
+            ServiceLogger.LogInformation("Creating local ChromeDriver. Selenium Manager will ensure the driver is available.");
             return CreateDriverInstanceWithChecks(chromeOptions, opts => new ChromeDriver(opts));
         }
         else
         {
+            ServiceLogger.LogInformation("Creating RemoteWebDriver for Chrome Grid at {GridUrl}", settings.SeleniumGridUrl);
             return new RemoteWebDriver(new Uri(settings.SeleniumGridUrl), chromeOptions);
         }
     }

--- a/SeleniumTraining/Core/Services/Drivers/EdgeDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/EdgeDriverFactoryService.cs
@@ -1,7 +1,4 @@
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Chrome;
-using WebDriverManager;
-using WebDriverManager.DriverConfigs.Impl;
 using OpenQA.Selenium.Edge;
 using System.Runtime.InteropServices;
 
@@ -93,11 +90,12 @@ public class EdgeDriverFactoryService : ChromiumDriverFactoryServiceBase
 
         if (string.IsNullOrEmpty(settings.SeleniumGridUrl))
         {
-            _ = new DriverManager().SetUpDriver(new EdgeConfig());
+            ServiceLogger.LogInformation("Creating local EdgeDriver. Selenium Manager will ensure the driver is available.");
             return CreateDriverInstanceWithChecks(edgeOptions, options => new EdgeDriver(options));
         }
         else
         {
+            ServiceLogger.LogInformation("Creating RemoteWebDriver for Edge Grid at {GridUrl}", settings.SeleniumGridUrl);
             return new RemoteWebDriver(new Uri(settings.SeleniumGridUrl), edgeOptions);
         }
     }

--- a/SeleniumTraining/Core/Services/Drivers/FirefoxDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/FirefoxDriverFactoryService.cs
@@ -1,7 +1,5 @@
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Remote;
-using WebDriverManager;
-using WebDriverManager.DriverConfigs.Impl;
 
 namespace SeleniumTraining.Core.Services.Drivers;
 
@@ -167,29 +165,20 @@ public class FirefoxDriverFactoryService : DriverFactoryServiceBase, IBrowserDri
 
         if (string.IsNullOrEmpty(settings.SeleniumGridUrl))
         {
-            ServiceLogger.LogInformation("Creating local FirefoxDriver instance.");
-
-            ServiceLogger.LogDebug("Attempting to set up GeckoDriver using WebDriverManager (FirefoxConfig).");
-            try
-            {
-                _ = new DriverManager().SetUpDriver(new FirefoxConfig());
-                ServiceLogger.LogInformation("WebDriverManager successfully completed GeckoDriver setup (FirefoxConfig).");
-            }
-            catch (Exception ex)
-            {
-                ServiceLogger.LogError(ex, "WebDriverManager failed to set up GeckoDriver (FirefoxConfig).");
-                throw;
-            }
+            ServiceLogger.LogInformation("Creating local FirefoxDriver instance. Selenium Manager will ensure the driver is available.");
 
             var localDriver = new FirefoxDriver(firefoxOptions);
             PerformVersionCheck(localDriver, Type.ToString(), _minimumSupportedVersion);
+
             return localDriver;
         }
         else
         {
             ServiceLogger.LogInformation("Creating RemoteWebDriver instance for Firefox Grid at {GridUrl}", settings.SeleniumGridUrl);
+
             var remoteDriver = new RemoteWebDriver(new Uri(settings.SeleniumGridUrl), firefoxOptions);
             PerformVersionCheck(remoteDriver, Type.ToString(), _minimumSupportedVersion);
+
             return remoteDriver;
         }
     }

--- a/SeleniumTraining/SeleniumTraining.csproj
+++ b/SeleniumTraining/SeleniumTraining.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
-    <PackageReference Include="WebDriverManager" Version="2.17.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit removes the WebDriverManager library and relies on Selenium Manager for browser driver management.

Changes include:

- Removed the WebDriverManager NuGet package.
- Removed WebDriverManager setup code from `ChromeDriverFactoryService`, `EdgeDriverFactoryService`, and `FirefoxDriverFactoryService`.
- Added logging to indicate that Selenium Manager will be used to manage browser drivers.