### PR TITLE
fix: change ShoppingCartPage.GetCartItems return type to List

### DIFF
--- a/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
@@ -40,10 +40,10 @@ public class ShoppingCartPage : BasePage
     /// <summary>
     /// Retrieves all items currently displayed in the shopping cart as a list of <see cref="CartItemComponent"/>s.
     /// </summary>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="CartItemComponent"/> representing the items in the cart.
-    /// Returns an empty collection if no items are found.</returns>
+    /// <returns>A <see cref="List{T}"/> of <see cref="CartItemComponent"/> representing the items in the cart.
+    /// Returns an empty list if no items are found.</returns>
     [AllureStep("Get all items from the shopping cart")]
-    public IEnumerable<CartItemComponent> GetCartItems()
+    public List<CartItemComponent> GetCartItems()
     {
         PageLogger.LogDebug("Attempting to find all cart item elements.");
 

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Cart.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Cart.cs
@@ -43,7 +43,7 @@ public partial class SauceDemoTests : BaseTest
         TestLogger.LogInformation("Navigating to shopping cart page.");
         ShoppingCartPage shoppingCartPage = inventoryPage.ClickShoppingCartLink();
 
-        var cartItems = shoppingCartPage.GetCartItems().ToList();
+        List<CartItemComponent> cartItems = shoppingCartPage.GetCartItems();
         cartItems.Count.ShouldBe(itemsToAdd.Count, $"Expected {itemsToAdd.Count} items in cart, but found {cartItems.Count}.");
         foreach (string itemName in itemsToAdd)
         {


### PR DESCRIPTION
This commit changes the return type of the `GetCartItems` method in the `ShoppingCartPage` class from `IEnumerable<CartItemComponent>` to `List<CartItemComponent>`. This change simplifies the usage of the method in the `SauceDemoTests.Cart.cs` test file, removing the need to convert the result to a list using `.ToList()`. The method documentation is also updated to reflect the change.