### PR TITLE
feat: add configurable default explicit wait time for WebDriver

### DIFF
--- a/SeleniumTraining/Core/BaseTest.cs
+++ b/SeleniumTraining/Core/BaseTest.cs
@@ -26,6 +26,7 @@ public abstract class BaseTest : IDisposable
 {
     private bool _disposed;
     private IServiceScope? _testScope; // DI scope for the current test
+    private IDisposable? _loggingScope; // For structured logging scope
 
     /// <summary>
     /// Gets the <see cref="BrowserType"/> for which this test fixture is configured to run.
@@ -124,9 +125,6 @@ public abstract class BaseTest : IDisposable
     /// </summary>
     /// <value>The resource monitor service. Null until <see cref="SetUp"/> completes successfully.</value>
     protected IResourceMonitorService ResourceMonitor { get; private set; } = null!;
-
-    private IDisposable? _loggingScope; // For structured logging scope
-
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BaseTest"/> class for a specific browser type.

--- a/SeleniumTraining/Pages/BasePage.cs
+++ b/SeleniumTraining/Pages/BasePage.cs
@@ -1,20 +1,17 @@
 namespace SeleniumTraining.Pages;
 
 /// <summary>
-/// Provides a foundational abstract class for all Page Objects within the Selenium test automation framework.
-/// It encapsulates common functionalities such as WebDriver and WebDriverWait instances, logging,
-/// settings access, retry mechanisms, and standardized page initialization routines (including
-/// waiting for page load and ensuring critical element visibility).
+/// Initializes a new instance of the <see cref="BasePage"/> abstract class.
+/// Sets up WebDriver, WebDriverWait, logging, settings, retry service, and performs
+/// initial page load and critical element visibility checks.
 /// </summary>
-/// <remarks>
-/// Derived Page Object classes must implement <see cref="CriticalElementsToEnsureVisible"/>.
-/// The constructor handles the initialization of core services and properties, and then orchestrates
-/// a multi-step page readiness check.
-/// This robust initialization helps in creating stable and reliable page object interactions.
-/// It provides the <see cref="FindElementOnPage(By)"/> method to locate elements. All lookups are performed "live"
-/// against the DOM to ensure element references are always current, which avoids stale element issues by design.
-/// This base class is designed to be used in conjunction with a DI container that provides the necessary services.
-/// </remarks>
+/// <param name="driver">The <see cref="IWebDriver"/> instance for browser interaction. Must not be null.</param>
+/// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating loggers. Must not be null.</param>
+/// <param name="settingsProvider">The <see cref="ISettingsProviderService"/> for accessing configurations. Must not be null.</param>
+/// <param name="retryService">The <see cref="IRetryService"/> for executing operations with retry logic. Must not be null.</param>
+/// <exception cref="ArgumentNullException">Thrown if <paramref name="driver"/>, <paramref name="loggerFactory"/>, <paramref name="settingsProvider"/>, or <paramref name="retryService"/> is null.</exception>
+/// <exception cref="WebDriverTimeoutException">Thrown if <see cref="WaitForPageLoad"/>, <see cref="EnsureCriticalElementsAreDisplayed"/>, or the additional readiness checks time out.</exception>
+/// <exception cref="Exception">Thrown for other unexpected errors during initialization.</exception>
 public abstract class BasePage
 {
     /// <summary>
@@ -103,8 +100,7 @@ public abstract class BasePage
         IWebDriver driver,
         ILoggerFactory loggerFactory,
         ISettingsProviderService settingsProvider,
-        IRetryService retryService,
-        int defaultTimeoutSeconds = 5
+        IRetryService retryService
     )
     {
         Driver = driver ?? throw new ArgumentNullException(nameof(driver));
@@ -117,12 +113,12 @@ public abstract class BasePage
         PageSettingsProvider = settingsProvider;
         FrameworkSettings = PageSettingsProvider.GetSettings<TestFrameworkSettings>("TestFrameworkSettings");
 
-        Wait = new WebDriverWait(driver, TimeSpan.FromSeconds(defaultTimeoutSeconds));
+        Wait = new WebDriverWait(driver, TimeSpan.FromSeconds(FrameworkSettings.DefaultExplicitWaitSeconds));
 
         PageLogger.LogInformation(
             "Initializing {PageName}. Default explicit wait timeout: {DefaultTimeoutSeconds}s. HighlightOnInteraction: {HighlightSetting}",
             PageName,
-            defaultTimeoutSeconds,
+            FrameworkSettings.DefaultExplicitWaitSeconds,
             FrameworkSettings.HighlightElementsOnInteraction
         );
 

--- a/SeleniumTraining/Utils/Settings/TestFrameworkSettings.cs
+++ b/SeleniumTraining/Utils/Settings/TestFrameworkSettings.cs
@@ -39,4 +39,19 @@ public class TestFrameworkSettings
     /// A short duration provides a visual cue without significantly slowing down test execution.
     /// </remarks>
     public int HighlightDurationMs { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets the default timeout in seconds for explicit waits (e.g., for WebDriverWait).
+    /// </summary>
+    /// <value>
+    /// The default timeout duration in seconds. Defaults to 10 seconds if not otherwise specified
+    /// in the configuration.
+    /// </value>
+    /// <remarks>
+    /// This central setting is used to initialize all <see cref="WebDriverWait"/> instances,
+    /// such as in the <see cref="BasePage"/> constructor, ensuring consistent wait times
+    /// across the framework. Making this configurable allows for easy adjustment of the framework's
+    /// patience based on environment or application performance.
+    /// </remarks>
+    public int DefaultExplicitWaitSeconds { get; set; } = 10;
 }

--- a/SeleniumTraining/appsettings.json
+++ b/SeleniumTraining/appsettings.json
@@ -34,7 +34,8 @@
   },
   "TestFrameworkSettings": {
     "HighlightElementsOnInteraction": true,
-    "HighlightDurationMs": 200
+    "HighlightDurationMs": 200,
+    "DefaultExplicitWaitSeconds": 10
   },
   "SeleniumGrid": {
     "Enabled": false,


### PR DESCRIPTION
This commit introduces a configurable default explicit wait time for `WebDriverWait` instances used in the `BasePage` class.

- Added a `DefaultExplicitWaitSeconds` property to the `TestFrameworkSettings` class, allowing the default wait time to be configured via `appsettings.json`. The default value is 10 seconds.
- Modified the `BasePage` constructor to use the `DefaultExplicitWaitSeconds` setting when creating the `WebDriverWait` instance.
- Updated logging in `BasePage` to include the configured default explicit wait time.
- Minor cleanup: moved `_loggingScope` declaration in `BaseTest` to the top with other private fields.

This change allows for easier adjustment of the framework's patience based on environment or application performance, centralizing the configuration of explicit wait times.