### PR TITLE
refactor: streamline BaseTest and introduce TestLifecycleManager for improved test lifecycle

### DIFF
--- a/SeleniumTraining/Core/BaseTest.cs
+++ b/SeleniumTraining/Core/BaseTest.cs
@@ -1,139 +1,70 @@
 namespace SeleniumTraining.Core;
 
 /// <summary>
-/// Provides a base class for all Selenium UI tests, encapsulating common setup,
-/// teardown, dependency injection, and test context management logic.
-/// It supports browser type specification for test fixtures and integrates with Allure reporting.
+/// Provides a lean base class for all UI tests, encapsulating DI scope management
+/// and delegation of test lifecycle events to an <see cref="ITestLifecycleManager"/>.
 /// </summary>
 /// <remarks>
 /// This abstract class is designed to be inherited by concrete test fixture classes.
-/// It handles:
+/// Its primary responsibilities are:
 /// <list type="bullet">
-///   <item><description>Dependency injection scope management per test using <see cref="TestHost.Services"/>.</description></item>
-///   <item><description>Resolution of core services like <see cref="ISettingsProviderService"/>, <see cref="ITestWebDriverManager"/>, <see cref="IResourceMonitorService"/>, etc.</description></item>
-///   <item><description>Initialization and cleanup of WebDriver via <see cref="ITestWebDriverManager"/>.</description></item>
-///   <item><description>Reporting setup and finalization via <see cref="ITestReporterService"/>, primarily for Allure.</description></item>
-///   <item><description>Resource monitoring via <see cref="IResourceMonitorService"/>, often integrated with <see cref="PerformanceTimer"/>.</description></item>
-///   <item><description>Correlation ID generation for tracing.</description></item>
-///   <item><description>Logging setup using <see cref="ILogger"/> specific to the test class.</description></item>
-///   <item><description>Handling of CI environment variables (TARGET_BROWSER_CI) to skip non-matching test fixtures.</description></item>
-///   <item><description>Proper resource disposal via <see cref="IDisposable"/>.</description></item>
+///   <item><description>Creating a new dependency injection scope for each test.</description></item>
+///   <item><description>Resolving the <see cref="ITestLifecycleManager"/> and a few other core services needed directly by tests.</description></item>
+///   <item><description>Hooking into NUnit's <c>[SetUp]</c> and <c>[TearDown]</c> attributes to delegate the orchestration of test setup and cleanup.</description></item>
+///   <item><description>Providing common properties like Loggers and Settings providers to derived test classes.</description></item>
 /// </list>
-/// Concrete test classes must provide a <see cref="BrowserType"/> to the constructor.
 /// </remarks>
 [AllureNUnit]
 public abstract class BaseTest : IDisposable
 {
-    private bool _disposed;
-    private IServiceScope? _testScope; // DI scope for the current test
-    private IDisposable? _loggingScope; // For structured logging scope
+    private IServiceScope? _testScope;
+    private IDisposable? _loggingScope;
 
     /// <summary>
-    /// Gets the <see cref="BrowserType"/> for which this test fixture is configured to run.
-    /// This is set via the constructor by derived test classes.
+    /// Gets the orchestrator for the current test's lifecycle, which manages
+    /// driver initialization, reporting, and cleanup.
     /// </summary>
-    /// <value>The configured browser type.</value>
-    protected BrowserType BrowserType { get; }
-
-    /// <summary>
-    /// Gets the browser-specific settings loaded for the current <see cref="BrowserType"/>.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The browser settings. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected BaseBrowserSettings BrowserSettings { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the <see cref="ILoggerFactory"/> instance used for creating loggers for page objects.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The logger factory for page objects. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected ILoggerFactory PageObjectLoggerFactory { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for accessing application and framework settings.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The settings provider service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected ISettingsProviderService SettingsProvider { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for managing directory paths for test artifacts.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The directory manager service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected IDirectoryManagerService DirectoryManager { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for managing the WebDriver lifecycle for the current test.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The WebDriver manager service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected ITestWebDriverManager WebDriverManager { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for initializing and finalizing test reports (e.g., for Allure).
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The test reporter service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected ITestReporterService TestReporter { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for performing visual regression testing.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The visual test service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected IVisualTestService VisualTester { get; private set; } = null!;
-
-    /// <summary>
-    /// Gets the service for executing actions with retry policies.
-    /// Initialized during <see cref="SetUp"/>.
-    /// </summary>
-    /// <value>The retry service. Null until <see cref="SetUp"/> completes successfully.</value>
-    protected IRetryService RetryService { get; private set; } = null!;
+    protected ITestLifecycleManager LifecycleManager { get; private set; } = null!;
 
     /// <summary>
     /// Gets the <see cref="ILogger"/> instance specifically for logging messages from the current test class.
-    /// It is initialized in <see cref="SetUp"/> and configured with the test class name.
     /// </summary>
-    /// <value>The logger for the current test. Null until <see cref="SetUp"/> completes successfully.</value>
-    public ILogger TestLogger { get; protected set; } = null!;
+    protected ILogger TestLogger { get; private set; } = null!;
 
     /// <summary>
-    /// Gets the full path to the directory where screenshots for the current test (or test class) will be saved.
-    /// This path is determined and ensured to exist during <see cref="SetUp"/>.
+    /// Gets the service for accessing application and framework settings.
     /// </summary>
-    /// <value>The screenshot directory path. Empty until <see cref="SetUp"/> completes successfully.</value>
-    protected string CurrentTestScreenshotDirectory { get; private set; } = string.Empty;
+    protected ISettingsProviderService SettingsProvider { get; private set; } = null!;
 
     /// <summary>
-    /// Gets the name of the current test class. This is typically derived from the type name of the concrete test fixture.
+    /// Gets the service for executing actions with retry policies.
     /// </summary>
-    /// <value>The name of the test class.</value>
-    protected string TestName { get; }
+    protected IRetryService RetryService { get; private set; } = null!;
 
     /// <summary>
-    /// Gets a unique correlation ID generated for the current test execution.
-    /// This ID is used for tracing logs and correlating activities across different services.
-    /// Initialized during <see cref="SetUp"/>.
+    /// Gets the <see cref="ILoggerFactory"/> instance used for creating loggers for page objects.
     /// </summary>
-    /// <value>The correlation ID. Empty until <see cref="SetUp"/> completes successfully.</value>
-    protected string CorrelationId { get; private set; } = string.Empty;
+    protected ILoggerFactory PageObjectLoggerFactory { get; private set; } = null!;
 
     /// <summary>
     /// Gets the service for monitoring process resource usage, such as memory.
-    /// Initialized during <see cref="SetUp"/>.
     /// </summary>
-    /// <value>The resource monitor service. Null until <see cref="SetUp"/> completes successfully.</value>
     protected IResourceMonitorService ResourceMonitor { get; private set; } = null!;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="BaseTest"/> class for a specific browser type.
+    /// Gets the name of the current test class.
+    /// </summary>
+    protected string TestName { get; }
+
+    /// <summary>
+    /// Gets the <see cref="BrowserType"/> for which this test fixture is configured to run.
+    /// </summary>
+    protected BrowserType BrowserType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseTest"/> class.
     /// </summary>
     /// <param name="browserType">The <see cref="BrowserType"/> on which the tests in this fixture are intended to run.</param>
-    /// <remarks>
-    /// This constructor sets the <see cref="BrowserType"/> and determines the <see cref="TestName"/>
-    /// based on the derived class's type name. Core service resolution and other setup occur in the <see cref="SetUp"/> method.
-    /// </remarks>
     protected BaseTest(BrowserType browserType)
     {
         BrowserType = browserType;
@@ -141,278 +72,83 @@ public abstract class BaseTest : IDisposable
     }
 
     /// <summary>
-    /// Performs setup operations common to all tests before each test method execution.
-    /// This includes:
-    /// <list type="bullet">
-    ///   <item><description>Creating a new DI scope and resolving necessary services (including <see cref="IResourceMonitorService"/>).</description></item>
-    ///   <item><description>Initializing the <see cref="TestLogger"/> with a logging scope including correlation ID and test context.</description></item>
-    ///   <item><description>Checking CI environment variables (TARGET_BROWSER_CI) and skipping tests if the fixture's <see cref="BrowserType"/> does not match.</description></item>
-    ///   <item><description>Loading browser-specific settings.</description></item>
-    ///   <item><description>Ensuring necessary output directories exist.</description></item>
-    ///   <item><description>Initializing the test report (e.g., for Allure).</description></item>
-    ///   <item><description>Initializing the WebDriver instance for the configured <see cref="BrowserType"/>.</description></item>
-    /// </list>
+    /// Performs setup operations before each test by creating a DI scope and
+    /// delegating the core setup orchestration to the <see cref="ITestLifecycleManager"/>.
     /// </summary>
-    /// <remarks>
-    /// This method is decorated with <see cref="SetUpAttribute"/> and will be called by NUnit before each test.
-    /// If a test fixture is skipped due to a browser mismatch in CI, <see cref="Assert.Ignore(string)"/> is called.
-    /// </remarks>
     [SetUp]
     public virtual void SetUp()
     {
         _testScope = TestHost.Services.CreateScope();
         IServiceProvider scopedServiceProvider = _testScope.ServiceProvider;
 
-        PageObjectLoggerFactory = scopedServiceProvider.GetRequiredService<ILoggerFactory>()!;
-        RetryService = scopedServiceProvider.GetRequiredService<IRetryService>()!;
-        ResourceMonitor = scopedServiceProvider.GetRequiredService<IResourceMonitorService>()!;
-        SettingsProvider = scopedServiceProvider.GetRequiredService<ISettingsProviderService>()!;
-        DirectoryManager = scopedServiceProvider.GetRequiredService<IDirectoryManagerService>()!;
-        WebDriverManager = scopedServiceProvider.GetRequiredService<ITestWebDriverManager>()!;
-        TestReporter = scopedServiceProvider.GetRequiredService<ITestReporterService>()!;
-        VisualTester = scopedServiceProvider.GetRequiredService<IVisualTestService>()!;
-
+        // Resolve only what BaseTest and derived tests absolutely need to access directly
+        PageObjectLoggerFactory = scopedServiceProvider.GetRequiredService<ILoggerFactory>();
         TestLogger = PageObjectLoggerFactory.CreateLogger(TestName);
+        SettingsProvider = scopedServiceProvider.GetRequiredService<ISettingsProviderService>();
+        RetryService = scopedServiceProvider.GetRequiredService<IRetryService>();
+        LifecycleManager = scopedServiceProvider.GetRequiredService<ITestLifecycleManager>();
+        ResourceMonitor = scopedServiceProvider.GetRequiredService<IResourceMonitorService>();
 
-        string? targetBrowserCiEnv = Environment.GetEnvironmentVariable("TARGET_BROWSER_CI");
-        TestLogger.LogInformation("CI Environment Variable TARGET_BROWSER_CI: '{TargetBrowserCiEnv}'", targetBrowserCiEnv ?? "Not Set");
-        TestLogger.LogInformation("NUnit Test Fixture is configured for BrowserType: '{BrowserType}'", BrowserType);
-
-        if (!string.IsNullOrEmpty(targetBrowserCiEnv))
-        {
-            if (Enum.TryParse(targetBrowserCiEnv, true, out BrowserType ciBrowserType))
-            {
-                if (BrowserType != ciBrowserType)
-                {
-                    string skipMessage = $"Skipping test fixture: Fixture is for '{BrowserType}', but CI job is targeting '{ciBrowserType}'.";
-                    TestLogger.LogWarning(
-                        "Skipping test fixture: Fixture is for '{BrowserType}', but CI job is targeting '{CiBrowserType}'.",
-                        BrowserType,
-                        ciBrowserType
-                    );
-                    Assert.Ignore(skipMessage);
-
-                    return;
-                }
-                TestLogger.LogInformation("CI Target Browser '{CiBrowserType}' matches Test Fixture Browser '{FixtureBrowserType}'. Proceeding with test setup.", ciBrowserType, BrowserType);
-            }
-            else
-            {
-                TestLogger.LogWarning(
-                    "Could not parse TARGET_BROWSER_CI environment variable '{TargetBrowserCiEnvVar}' to a known BrowserType. Running test as per fixture: {FixtureBrowserType}",
-                    targetBrowserCiEnv,
-                    BrowserType
-                );
-            }
-        }
-        else
-        {
-            TestLogger.LogInformation("TARGET_BROWSER_CI environment variable not set (likely a local run). Running test as per fixture: {FixtureBrowserType}", BrowserType);
-        }
-
-        CorrelationId = Guid.NewGuid().ToString("N")[..12];
-        string testLogFileKey = TestName;
-
+        // Set up a logging scope with context
+        string correlationId = Guid.NewGuid().ToString("N")[..12];
         var scopeProperties = new Dictionary<string, object>
         {
-            ["CorrelationId"] = CorrelationId,
+            ["CorrelationId"] = correlationId,
             ["TestClassName"] = TestName,
             ["TestMethodName"] = TestContext.CurrentContext.Test.MethodName ?? "UnknownMethod",
             ["BrowserType"] = BrowserType.ToString(),
-            ["TestLogFileKey"] = testLogFileKey
+            ["TestLogFileKey"] = TestName
         };
         _loggingScope = TestLogger.BeginScope(scopeProperties);
 
-        TestLogger.LogInformation("BaseTest SetUp started for test: {TestClass}", TestName);
-        TestLogger.LogDebug("Resolved core services. CorrelationId: {CorrelationId}", CorrelationId);
+        TestLogger.LogInformation("BaseTest SetUp started for: {TestName}", TestName);
 
-        BrowserSettings = SettingsProvider.GetBrowserSettings(BrowserType);
-        TestLogger.LogDebug("Browser settings loaded: Headless={Headless}, Timeout={Timeout}s", BrowserSettings.Headless, BrowserSettings.TimeoutSeconds);
+        // DELEGATE all setup orchestration to the lifecycle manager
+        LifecycleManager.InitializeTestScope(TestName, TestContext.CurrentContext, BrowserType);
 
-
-        DirectoryManager.EnsureBaseDirectoriesExist();
-
-        CurrentTestScreenshotDirectory = DirectoryManager.GetAndEnsureTestScreenshotDirectory(TestName);
-        TestLogger.LogInformation("Screenshot directory prepared: {ScreenshotDir}", CurrentTestScreenshotDirectory);
-
-        string? baseMethodName = TestContext.CurrentContext.Test.MethodName ?? "UnknownMethod";
-        string browserNameString = BrowserType.ToString();
-        string allureDisplayName = $"{baseMethodName} ({browserNameString})";
-
-        TestLogger.LogDebug("Initializing test report via TestReporter. AllureDisplayName: {AllureDisplayName}", allureDisplayName);
-        TestReporter.InitializeTestReport(allureDisplayName, browserNameString, CorrelationId);
-        TestLogger.LogInformation("Test report initialized for Allure.");
-
-        TestLogger.LogDebug("Initializing WebDriver via WebDriverManager for {Browser}.", BrowserType);
-        WebDriverManager.InitializeDriver(BrowserType, TestName, CorrelationId);
-        TestLogger.LogInformation("WebDriver initialization requested for {Browser}.", BrowserType);
-
-        TestLogger.LogInformation("BaseTest SetUp completed for {TestClass}.", TestName);
+        TestLogger.LogInformation("BaseTest SetUp completed for: {TestName}", TestName);
     }
 
     /// <summary>
-    /// Performs cleanup operations after each test. This includes:
-    /// <list type="bullet">
-    ///   <item><description>Finalizing the test report (including taking screenshots on failure).</description></item>
-    ///   <item><description>Quitting the WebDriver instance to close the browser.</description></item>
-    ///   <item><description>Disposing the logging and DI scopes for the test.</description></item>
-    /// </list>
+    /// Performs cleanup operations after each test by delegating to the
+    /// <see cref="ITestLifecycleManager"/> and then disposing the DI scope.
     /// </summary>
     [TearDown]
     public void Cleanup()
     {
-        if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped &&
-            TestContext.CurrentContext.Result.Message != null &&
-            TestContext.CurrentContext.Result.Message.Contains("Skipping test fixture:"))
+        // Skip finalization if the test was ignored during setup
+        if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped)
         {
-            TestLogger.LogInformation("BaseTest Cleanup (NUnit TearDown) skipped due to Assert.Ignore in SetUp for test: {TestFullName}", TestContext.CurrentContext.Test.FullName);
-            _loggingScope?.Dispose();
-            _testScope?.Dispose();
-
+            TestLogger.LogInformation("BaseTest Cleanup skipped due to Assert.Ignore in SetUp.");
             return;
         }
 
-        TestLogger.LogInformation("BaseTest Cleanup (NUnit TearDown) started for test: {TestFullName}", TestContext.CurrentContext.Test.FullName);
-
-        IWebDriver? driverForActions = null;
-        if (WebDriverManager != null && WebDriverManager.IsDriverActive)
-        {
-            try
-            {
-                driverForActions = WebDriverManager.GetDriver();
-                TestLogger.LogDebug("WebDriver instance retrieved for cleanup actions.");
-            }
-            catch (InvalidOperationException ex)
-            {
-                TestLogger.LogWarning(
-                    ex,
-                    "Failed to get WebDriver instance during Cleanup for test {TestFullName}. Screenshot/reporting might be affected.",
-                    TestContext.CurrentContext.Test.FullName
-                );
-            }
-        }
-        else
-        {
-            TestLogger.LogWarning("WebDriver was not active at the start of Cleanup for {TestFullName}.", TestContext.CurrentContext.Test.FullName);
-        }
-
-        if (TestReporter != null)
-        {
-            TestLogger.LogDebug("Finalizing test report via TestReporter.");
-
-            TestReporter.FinalizeTestReport(
-                TestContext.CurrentContext,
-                driverForActions,
-                BrowserType,
-                CurrentTestScreenshotDirectory,
-                CorrelationId
-            );
-
-            TestLogger.LogInformation(
-                "Test report finalized. Test Outcome: {OutcomeStatus} - {OutcomeLabel}",
-                TestContext.CurrentContext.Result.Outcome.Status,
-                TestContext.CurrentContext.Result.Outcome.Label
-            );
-        }
-        else
-        {
-            TestLogger.LogWarning("TestReporter was null during Cleanup. Report finalization skipped for {TestFullName}.", TestContext.CurrentContext.Test.FullName);
-        }
+        TestLogger.LogInformation("BaseTest Cleanup started for: {TestFullName}", TestContext.CurrentContext.Test.FullName);
 
         try
         {
-            if (WebDriverManager != null && WebDriverManager.IsDriverActive)
-            {
-                TestLogger.LogDebug("Quitting WebDriver via WebDriverManager in TearDown.");
-                WebDriverManager.QuitDriver();
-                TestLogger.LogInformation("WebDriver quit successfully in TearDown for {TestName}.", TestName);
-            }
+            // DELEGATE all teardown orchestration to the lifecycle manager
+            LifecycleManager.FinalizeTestScope(TestContext.CurrentContext);
+            TestLogger.LogInformation("Test Lifecycle finalized successfully.");
         }
         catch (Exception ex)
         {
-            TestLogger.LogError(ex, "Exception during WebDriverManager.QuitDriver in TearDown for test {TestName}.", TestName);
+            TestLogger.LogError(ex, "An unexpected error occurred during test finalization.");
         }
-
-        TestLogger.LogInformation("BaseTest Cleanup (NUnit TearDown) completed for {TestFullName}.", TestContext.CurrentContext.Test.FullName);
-
-        _loggingScope?.Dispose();
-        _loggingScope = null;
-
-        _testScope?.Dispose();
-        _testScope = null;
+        finally
+        {
+            // Dispose logging and DI scopes
+            _loggingScope?.Dispose();
+            _testScope?.Dispose();
+            TestLogger.LogInformation("BaseTest Cleanup completed.");
+        }
     }
 
-    /// <summary>
-    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources,
-    /// conforming to the <see cref="IDisposable"/> interface.
-    /// This is the primary method for resource cleanup and is called by the NUnit framework
-    /// or test runner at the end of the fixture's lifecycle.
-    /// </summary>
-    /// <remarks>
-    /// This implementation follows the standard dispose pattern.
-    /// It calls the protected virtual <see cref="Dispose(bool)"/> method
-    /// and suppresses finalization.
-    /// </remarks>
+    /// <inheritdoc/>
     public void Dispose()
     {
-        Dispose(true);
+        _loggingScope?.Dispose();
+        _testScope?.Dispose();
         GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Releases managed resources. It ensures that all disposable services resolved
-    /// for the test scope are disposed. The WebDriver instance itself is quit in the `[TearDown]` method.
-    /// </summary>
-    protected virtual void Dispose(bool disposing)
-    {
-        string currentTestNameForDispose = TestName ?? "UnknownTest_Dispose";
-
-        if (_disposed)
-        {
-            TestLogger.LogDebug("BaseTest for '{EffectiveTestName}' already disposed (disposing: {IsDisposing}). Skipping.", currentTestNameForDispose, disposing);
-            return;
-        }
-
-        if (disposing)
-        {
-            TestLogger.LogDebug("Disposing WebDriverManager instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (WebDriverManager as IDisposable)?.Dispose();
-
-            TestLogger.LogDebug("Disposing TestReporter instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (TestReporter as IDisposable)?.Dispose();
-
-            TestLogger.LogDebug("Disposing ConfigProvider instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (SettingsProvider as IDisposable)?.Dispose();
-
-            TestLogger.LogDebug("Disposing DirectoryManager instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (DirectoryManager as IDisposable)?.Dispose();
-
-            TestLogger.LogDebug("Disposing VisualTester instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (VisualTester as IDisposable)?.Dispose();
-
-            TestLogger.LogDebug("Disposing RetryService instance for {EffectiveTestName}.", currentTestNameForDispose);
-            (RetryService as IDisposable)?.Dispose();
-
-            TestLogger.LogInformation("Managed services disposed for {EffectiveTestName}.", currentTestNameForDispose);
-        }
-
-        if (_loggingScope != null)
-        {
-            TestLogger.LogDebug("Disposing logging scope for {EffectiveTestName}.", currentTestNameForDispose);
-            _loggingScope.Dispose();
-            _loggingScope = null;
-
-            Serilog.Log.Debug("BaseTest logging scope explicitly disposed for {EffectiveTestName}.", currentTestNameForDispose);
-        }
-
-        if (_testScope != null)
-        {
-            TestLogger.LogWarning("Test-specific DI scope was not null in BaseTest.Dispose(true). Disposing now. Test: {TestName}", TestName);
-            _testScope.Dispose();
-            _testScope = null;
-        }
-
-        _disposed = true;
-        TestLogger.LogInformation("BaseTest Dispose({IsDisposing}) completed for {EffectiveTestName}.", disposing, currentTestNameForDispose);
     }
 }

--- a/SeleniumTraining/Core/Extensions/AppServiceCollectionExtensions.cs
+++ b/SeleniumTraining/Core/Extensions/AppServiceCollectionExtensions.cs
@@ -67,6 +67,7 @@ public static class AppServiceCollectionExtensions
             .AddSingleton<IBrowserDriverFactoryService, EdgeDriverFactoryService>()
             .AddSingleton<IBrowserDriverFactoryService, FirefoxDriverFactoryService>()
             .AddSingleton<IThreadLocalDriverStorageService, ThreadLocalDriverStorageService>()
+            .AddScoped<ITestLifecycleManager, TestLifecycleManager>()
             .AddTransient<IDriverInitializationService, DriverInitializationService>()
             .AddTransient<IDriverLifecycleService, DriverLifecycleService>()
             .AddScoped<ITestWebDriverManager, TestWebDriverManager>()

--- a/SeleniumTraining/Core/Services/Contracts/ITestLifecycleManager.cs
+++ b/SeleniumTraining/Core/Services/Contracts/ITestLifecycleManager.cs
@@ -1,0 +1,39 @@
+namespace SeleniumTraining.Core.Services.Contracts;
+
+/// <summary>
+/// Defines the contract for a service that orchestrates the complete lifecycle
+/// of a single test, from setup and initialization to finalization and reporting.
+/// </summary>
+/// <remarks>
+/// This service acts as a central coordinator, ensuring that the driver is initialized,
+/// reports are set up, and all resources are properly cleaned up in a consistent sequence for each test.
+/// </remarks>
+public interface ITestLifecycleManager
+{
+    /// <summary>
+    /// Gets the service for managing the WebDriver lifecycle for the current test.
+    /// </summary>
+    public ITestWebDriverManager WebDriverManager { get; }
+
+    /// <summary>
+    /// Gets the service for performing visual regression testing.
+    /// </summary>
+    public IVisualTestService VisualTester { get; }
+
+    /// <summary>
+    /// Initializes the test environment for a single test execution. This includes
+    /// running CI environment checks, preparing directories, initializing reports,
+    /// and creating the WebDriver instance.
+    /// </summary>
+    /// <param name="testName">The name of the current test class, used for logging and directory creation.</param>
+    /// <param name="testContext">The NUnit TestContext for the currently running test.</param>
+    /// <param name="browserType">The browser the test is configured to run on.</param>
+    public void InitializeTestScope(string testName, TestContext testContext, BrowserType browserType);
+
+    /// <summary>
+    /// Finalizes the test execution. This includes generating reports (with screenshots
+    /// on failure) and safely quitting the WebDriver.
+    /// </summary>
+    /// <param name="testContext">The NUnit TestContext for the completed test, containing the test outcome.</param>
+    public void FinalizeTestScope(TestContext testContext);
+}

--- a/SeleniumTraining/Core/Services/RetryService.cs
+++ b/SeleniumTraining/Core/Services/RetryService.cs
@@ -42,7 +42,7 @@ public class RetryService : BaseService, IRetryService
         {
             try
             {
-                var exceptionType = Type.GetType(name, throwOnError: false); // Set throwOnError to false for graceful handling
+                var exceptionType = Type.GetType(name, throwOnError: false);
                 if (exceptionType != null)
                 {
                     _retryableExceptionTypes.Add(exceptionType);

--- a/SeleniumTraining/Core/Services/TestLifecycleManager.cs
+++ b/SeleniumTraining/Core/Services/TestLifecycleManager.cs
@@ -1,0 +1,132 @@
+namespace SeleniumTraining.Core.Services;
+
+/// <summary>
+/// Orchestrates the setup and teardown logic for a single test execution.
+/// This class is responsible for initializing the driver, setting up reporting,
+/// and ensuring everything is cleaned up correctly.
+/// </summary>
+/// <remarks>
+/// This is a scoped service that uses constructor injection to receive all its
+/// dependencies. It is resolved once per test and contains the core logic
+/// that was previously in BaseTest, adhering to the Single Responsibility Principle.
+/// </remarks>
+public class TestLifecycleManager : BaseService, ITestLifecycleManager
+{
+    private readonly ITestReporterService _testReporter;
+    private readonly IDirectoryManagerService _directoryManager;
+
+    /// <inheritdoc/>
+    public ITestWebDriverManager WebDriverManager { get; }
+
+    /// <inheritdoc/>
+    public IVisualTestService VisualTester { get; }
+
+    /// <summary>
+    /// Gets the browser type for the current test execution.
+    /// </summary>
+    public BrowserType CurrentBrowserType { get; private set; }
+
+    /// <summary>
+    /// Gets the full path to the screenshot directory for the current test.
+    /// </summary>
+    public string CurrentTestScreenshotDirectory { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the unique correlation ID for the current test execution.
+    /// </summary>
+    public string CorrelationId { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestLifecycleManager"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">The logger factory.</param>
+    /// <param name="webDriverManager">The service for managing the WebDriver instance.</param>
+    /// <param name="testReporter">The service for initializing and finalizing test reports.</param>
+    /// <param name="directoryManager">The service for managing test artifact directories.</param>
+    /// <param name="visualTester">The service for performing visual regression testing.</param>
+    public TestLifecycleManager(
+        ILoggerFactory loggerFactory,
+        ITestWebDriverManager webDriverManager,
+        ITestReporterService testReporter,
+        IDirectoryManagerService directoryManager,
+        IVisualTestService visualTester
+    )
+        : base(loggerFactory)
+    {
+        WebDriverManager = webDriverManager;
+        _testReporter = testReporter;
+        _directoryManager = directoryManager;
+        VisualTester = visualTester;
+    }
+
+    /// <inheritdoc/>
+    public void InitializeTestScope(string testName, TestContext testContext, BrowserType browserType)
+    {
+        CurrentBrowserType = browserType;
+
+        // CI Browser Check Logic
+        string? targetBrowserCiEnv = Environment.GetEnvironmentVariable("TARGET_BROWSER_CI");
+        if (!string.IsNullOrEmpty(targetBrowserCiEnv) && Enum.TryParse(targetBrowserCiEnv, true, out BrowserType ciBrowserType))
+        {
+            if (browserType != ciBrowserType)
+            {
+                string skipMessage = $"Skipping test fixture: Fixture is for '{browserType}', but CI job is targeting '{ciBrowserType}'.";
+                ServiceLogger.LogWarning(
+                    "Skipping test fixture: Fixture is for '{BrowserType}', but CI job is targeting '{CiBrowserType}'.",
+                    browserType,
+                    ciBrowserType
+                );
+                Assert.Ignore(skipMessage);
+                return;
+            }
+        }
+
+        CorrelationId = Guid.NewGuid().ToString("N")[..12];
+        CurrentTestScreenshotDirectory = _directoryManager.GetAndEnsureTestScreenshotDirectory(testName);
+        ServiceLogger.LogInformation("Screenshot directory prepared: {ScreenshotDir}", CurrentTestScreenshotDirectory);
+
+        // Initialize Reporting
+        string? baseMethodName = testContext.Test.MethodName ?? "UnknownMethod";
+        string allureDisplayName = $"{baseMethodName} ({browserType})";
+        _testReporter.InitializeTestReport(allureDisplayName, browserType.ToString(), CorrelationId);
+        ServiceLogger.LogInformation("Test report initialized for Allure.");
+
+        // Initialize WebDriver
+        ServiceLogger.LogDebug("Initializing WebDriver via WebDriverManager for {Browser}.", browserType);
+        WebDriverManager.InitializeDriver(browserType, testName, CorrelationId);
+        ServiceLogger.LogInformation("WebDriver initialization requested for {Browser}.", browserType);
+    }
+
+    /// <inheritdoc/>
+    public void FinalizeTestScope(TestContext testContext)
+    {
+        IWebDriver? driverForActions = null;
+        if (WebDriverManager.IsDriverActive)
+        {
+            try
+            {
+                driverForActions = WebDriverManager.GetDriver();
+            }
+            catch (Exception ex)
+            {
+                ServiceLogger.LogWarning(ex, "Failed to get WebDriver during FinalizeTestScope. Screenshot may be missed.");
+            }
+        }
+
+        // Finalize Reporting (takes screenshot on failure)
+        _testReporter.FinalizeTestReport(
+            testContext,
+            driverForActions,
+            CurrentBrowserType,
+            CurrentTestScreenshotDirectory,
+            CorrelationId
+        );
+
+        // Quit WebDriver
+        if (WebDriverManager.IsDriverActive)
+        {
+            ServiceLogger.LogDebug("Quitting WebDriver via WebDriverManager in FinalizeTestScope.");
+            WebDriverManager.QuitDriver();
+        }
+    }
+}

--- a/SeleniumTraining/GlobalUsings.cs
+++ b/SeleniumTraining/GlobalUsings.cs
@@ -30,7 +30,6 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Options;
 global using System.ComponentModel.DataAnnotations;
 global using System.Collections.ObjectModel;
-global using NUnit.Framework;
 global using Shouldly;
 global using Allure.NUnit;
 global using Allure.NUnit.Attributes;

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Base.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Base.cs
@@ -81,7 +81,7 @@ public partial class SauceDemoTests : BaseTest
         TestLogger.LogInformation("Attempting to navigate to SauceDemo URL: {SauceDemoAppUrl}", _sauceDemoSettings.PageUrl);
         try
         {
-            IWebDriver driver = WebDriverManager.GetDriver();
+            IWebDriver driver = LifecycleManager.WebDriverManager.GetDriver();
 
             using (new PerformanceTimer(
                 $"NavigateTo_{LoginPageMap.PageTitle}",
@@ -113,7 +113,7 @@ public partial class SauceDemoTests : BaseTest
                 "Page title verification failed for URL {SauceDemoAppUrl}. Expected '{ExpectedTitle}', Actual '{ActualTitle}'. Message: {ShouldlyMessage}",
                 _sauceDemoSettings.PageUrl,
                 LoginPageMap.PageTitle,
-                WebDriverManager.GetDriver().Title,
+                LifecycleManager.WebDriverManager.GetDriver().Title,
                 ex.Message
             );
             throw;

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Cart.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Cart.cs
@@ -33,7 +33,7 @@ public partial class SauceDemoTests : BaseTest
         var itemsToAdd = new List<string> { "Sauce Labs Backpack", "Sauce Labs Bike Light", "Sauce Labs Bolt T-Shirt" };
         var itemsToRemove = new List<string> { "Sauce Labs Bike Light", "Sauce Labs Bolt T-Shirt" };
         string itemToRemain = "Sauce Labs Backpack";
-        var wait = new WebDriverWait(WebDriverManager.GetDriver(), TimeSpan.FromSeconds(10));
+        var wait = new WebDriverWait(LifecycleManager.WebDriverManager.GetDriver(), TimeSpan.FromSeconds(10));
 
         // --- Login Step ---
         InventoryPage inventoryPage = LoginAndAddItemsToCart(itemsToAdd);
@@ -43,7 +43,7 @@ public partial class SauceDemoTests : BaseTest
         TestLogger.LogInformation("Navigating to shopping cart page.");
         ShoppingCartPage shoppingCartPage = inventoryPage.ClickShoppingCartLink();
 
-        List<CartItemComponent> cartItems = shoppingCartPage.GetCartItems();
+        var cartItems = shoppingCartPage.GetCartItems().ToList();
         cartItems.Count.ShouldBe(itemsToAdd.Count, $"Expected {itemsToAdd.Count} items in cart, but found {cartItems.Count}.");
         foreach (string itemName in itemsToAdd)
         {

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Helpers.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Helpers.cs
@@ -23,7 +23,7 @@ public partial class SauceDemoTests : BaseTest
             resourceMonitor: ResourceMonitor
         );
 
-        LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+        LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
         BasePage resultPage = loginPage
             .EnterUsername(_sauceDemoSettings.LoginUsernameStandardUser)
             .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -61,7 +61,7 @@ public partial class SauceDemoTests : BaseTest
         );
 
         var allInventoryItems = inventoryPage.GetInventoryItems().ToList();
-        var wait = new WebDriverWait(WebDriverManager.GetDriver(), TimeSpan.FromSeconds(10));
+        var wait = new WebDriverWait(LifecycleManager.WebDriverManager.GetDriver(), TimeSpan.FromSeconds(10));
 
         foreach (string itemName in itemsToAddToCart)
         {

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Inventory.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Inventory.cs
@@ -60,7 +60,7 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
 
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameStandardUser)
@@ -166,7 +166,7 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameProblemUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -303,7 +303,7 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernamePerformanceGlitchUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -399,7 +399,7 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameErrorUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -424,7 +424,7 @@ public partial class SauceDemoTests : BaseTest
         );
 
         bool cartInteractionsVerified = false;
-        IWebDriver driver = WebDriverManager.GetDriver();
+        IWebDriver driver = LifecycleManager.WebDriverManager.GetDriver();
 
         try
         {
@@ -568,12 +568,12 @@ public partial class SauceDemoTests : BaseTest
         );
 
         bool testStepsSuccessful = false;
-        IWebDriver driver = WebDriverManager.GetDriver();
+        IWebDriver driver = LifecycleManager.WebDriverManager.GetDriver();
 
         try
         {
             TestLogger.LogDebug("Instantiating LoginPage for {TestName}.", currentTestName);
-            LoginPage loginPage = new(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
 
             TestLogger.LogInformation(
                 "Attempting login with username: {LoginUsername} (visual_user) using Click action for {TestName}.",
@@ -607,7 +607,7 @@ public partial class SauceDemoTests : BaseTest
                 currentTestName
             );
 
-            VisualTester.AssertVisualMatch(
+            LifecycleManager.VisualTester.AssertVisualMatch(
                 baselineIdentifier: fullPageBaselineId,
                 testName: TestName,
                 browserType: BrowserType
@@ -637,7 +637,7 @@ public partial class SauceDemoTests : BaseTest
                             currentTestName
                         );
 
-                        VisualTester.AssertVisualMatch(
+                        LifecycleManager.VisualTester.AssertVisualMatch(
                             baselineIdentifier: boltTShirtImageBaselineId,
                             testName: TestName,
                             browserType: BrowserType,

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Login.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Login.cs
@@ -45,7 +45,7 @@ public partial class SauceDemoTests : BaseTest
         try
         {
             TestLogger.LogDebug("Instantiating LoginPage.");
-            var initialPage = new LoginPage(WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            var initialPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
 
             loginPage = initialPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameLockedOutUser)


### PR DESCRIPTION
This commit refactors the `BaseTest` class to streamline its responsibilities and introduces a `TestLifecycleManager` to handle test lifecycle events, such as driver initialization, reporting, and cleanup.

- Reduces the responsibilities of `BaseTest` to DI scope management and delegation of test lifecycle events.
- Introduces `ITestLifecycleManager` and its implementation `TestLifecycleManager` to orchestrate test setup and cleanup.
- Moves WebDriver initialization, report setup/finalization, and screenshot directory management to the `TestLifecycleManager`.
- Updates `SauceDemoTests` to use `LifecycleManager.WebDriverManager.GetDriver()` instead of `WebDriverManager.GetDriver()`.
- Registers `ITestLifecycleManager` as a scoped service.
- Removes direct disposal of services in `BaseTest.Dispose()` as they are now managed by the DI container.
- Removes `NUnit.Framework` global using.

This change improves the separation of concerns, makes `BaseTest` leaner, and centralizes test lifecycle management for better maintainability and extensibility.