### PR TITLE
refactor(pages): introduce explicit page load validation

### DIFF
--- a/SeleniumTraining/Pages/BasePage.cs
+++ b/SeleniumTraining/Pages/BasePage.cs
@@ -116,12 +116,20 @@ public abstract class BasePage
         Wait = new WebDriverWait(driver, TimeSpan.FromSeconds(FrameworkSettings.DefaultExplicitWaitSeconds));
 
         PageLogger.LogInformation(
-            "Initializing {PageName}. Default explicit wait timeout: {DefaultTimeoutSeconds}s. HighlightOnInteraction: {HighlightSetting}",
-            PageName,
-            FrameworkSettings.DefaultExplicitWaitSeconds,
-            FrameworkSettings.HighlightElementsOnInteraction
+            "Instantiated {PageName}. Page-load validation will be performed by AssertPageIsLoaded().",
+            PageName
         );
+    }
 
+    /// <summary>
+    /// Asserts that the page is fully loaded by waiting for the document to be ready
+    /// and ensuring all critical elements are visible. This method should be called
+    /// immediately after instantiating a page object.
+    /// </summary>
+    /// <returns>The current page instance for fluent chaining.</returns>
+    [AllureStep("Asserting that page '{PageName}' is loaded and ready")]
+    public virtual BasePage AssertPageIsLoaded()
+    {
         var pageLoadTimer = new PerformanceTimer(
             $"PageLoad_{PageName}",
             PageLogger,
@@ -153,17 +161,17 @@ public abstract class BasePage
                 PageLogger.LogInformation("Additional base readiness conditions met for {PageName}.", PageName);
             }
 
-            PageLogger.LogInformation("{PageName} fully initialized successfully.", PageName);
+            PageLogger.LogInformation("{PageName} fully loaded and validated successfully.", PageName);
             initializationSuccessful = true;
         }
         catch (WebDriverTimeoutException ex)
         {
-            PageLogger.LogError(ex, "{PageName} timed out during initialization. Timeout: {TimeoutSeconds}s.", PageName, Wait.Timeout.TotalSeconds);
+            PageLogger.LogError(ex, "{PageName} timed out during page load validation. Timeout: {TimeoutSeconds}s.", PageName, Wait.Timeout.TotalSeconds);
             throw;
         }
         catch (Exception ex)
         {
-            PageLogger.LogError(ex, "An unexpected error occurred during page initialization for {PageName}.", PageName);
+            PageLogger.LogError(ex, "An unexpected error occurred during page load validation for {PageName}.", PageName);
             throw;
         }
         finally
@@ -176,6 +184,8 @@ public abstract class BasePage
                     : null
             );
         }
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/CheckoutCompletePage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/CheckoutCompletePage.cs
@@ -19,13 +19,28 @@ public class CheckoutCompletePage : BasePage
     public CheckoutCompletePage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
+
+    /// <summary>
+    /// Asserts that the CheckoutCompletePage is fully loaded by performing base checks and
+    /// verifying the page URL and title.
+    /// </summary>
+    /// <returns>The current CheckoutCompletePage instance for fluent chaining.</returns>
+    public override CheckoutCompletePage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
+
+        PageLogger.LogDebug("Performing {PageName}-specific validation (URL and Title check).", PageName);
         string expectedPath = CheckoutCompletePageMap.PageUrlPath;
         bool urlCorrect = Wait.Until(d => d.Url.Contains(expectedPath, StringComparison.OrdinalIgnoreCase));
         urlCorrect.ShouldBeTrue($"Landed on Checkout Complete page, but URL was expected to contain '{expectedPath}'. Current URL: '{Driver.Url}'.");
 
         IWebElement titleElement = FindElementOnPage(CheckoutCompletePageMap.PageTitle);
         titleElement.Text.ShouldBe(CheckoutCompletePageMap.PageTitleText, $"Page title should be '{CheckoutCompletePageMap.PageTitleText}'.");
-        PageLogger.LogInformation("{PageName} loaded and URL/Title verified.", PageName);
+        PageLogger.LogInformation("{PageName} URL and Title verified.", PageName);
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/CheckoutStepOnePage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/CheckoutStepOnePage.cs
@@ -21,13 +21,28 @@ public class CheckoutStepOnePage : BasePage
     public CheckoutStepOnePage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
+
+    /// <summary>
+    /// Asserts that the CheckoutStepOnePage is fully loaded by performing base checks and
+    /// verifying the page URL and title.
+    /// </summary>
+    /// <returns>The current CheckoutStepOnePage instance for fluent chaining.</returns>
+    public override CheckoutStepOnePage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
+
+        PageLogger.LogDebug("Performing {PageName}-specific validation (URL and Title check).", PageName);
         string expectedPath = CheckoutStepOnePageMap.PageUrlPath;
         bool urlCorrect = Wait.Until(d => d.Url.Contains(expectedPath, StringComparison.OrdinalIgnoreCase));
         urlCorrect.ShouldBeTrue($"Landed on Checkout Step One page, but URL was expected to contain '{expectedPath}'. Current URL: '{Driver.Url}'.");
 
         IWebElement titleElement = FindElementOnPage(CheckoutStepOnePageMap.PageTitle);
         titleElement.Text.ShouldBe(CheckoutStepOnePageMap.PageTitleText, $"Page title should be '{CheckoutStepOnePageMap.PageTitleText}'.");
-        PageLogger.LogInformation("{PageName} loaded and URL/Title verified.", PageName);
+        PageLogger.LogInformation("{PageName} URL and Title verified.", PageName);
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/CheckoutStepTwoPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/CheckoutStepTwoPage.cs
@@ -20,13 +20,28 @@ public class CheckoutStepTwoPage : BasePage
     public CheckoutStepTwoPage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
+
+    /// <summary>
+    /// Asserts that the CheckoutStepTwoPage is fully loaded by performing base checks and
+    /// verifying the page URL and title.
+    /// </summary>
+    /// <returns>The current CheckoutStepTwoPage instance for fluent chaining.</returns>
+    public override CheckoutStepTwoPage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
+
+        PageLogger.LogDebug("Performing {PageName}-specific validation (URL and Title check).", PageName);
         string expectedPath = CheckoutStepTwoPageMap.PageUrlPath;
         bool urlCorrect = Wait.Until(d => d.Url.Contains(expectedPath, StringComparison.OrdinalIgnoreCase));
         urlCorrect.ShouldBeTrue($"Landed on Checkout Step Two page, but URL was expected to contain '{expectedPath}'. Current URL: '{Driver.Url}'.");
 
         IWebElement titleElement = FindElementOnPage(CheckoutStepTwoPageMap.PageTitle);
         titleElement.Text.ShouldBe(CheckoutStepTwoPageMap.PageTitleText, $"Page title should be '{CheckoutStepTwoPageMap.PageTitleText}'.");
-        PageLogger.LogInformation("{PageName} loaded and URL/Title verified.", PageName);
+        PageLogger.LogInformation("{PageName} URL and Title verified.", PageName);
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/InventoryPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/InventoryPage.cs
@@ -40,8 +40,20 @@ public class InventoryPage : BasePage
     public InventoryPage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
-        PageLogger.LogDebug("{PageName} instance fully created and validated (critical elements checked by BasePage).", PageName);
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
+
+    /// <summary>
+    /// Asserts that the InventoryPage is fully loaded by performing base checks and
+    /// waiting for the page to be fully ready with a minimum number of items.
+    /// </summary>
+    /// <returns>The current InventoryPage instance for fluent chaining.</returns>
+    public override InventoryPage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
         WaitForPageToBeFullyReady();
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/LoginPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/LoginPage.cs
@@ -36,21 +36,31 @@ public class LoginPage : BasePage
     public LoginPage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
 
-        PageLogger.LogDebug("Performing LoginPage-specific initialization checks for {PageName}.", PageName);
+    /// <summary>
+    /// Asserts that the LoginPage is fully loaded by performing base checks and
+    /// verifying the page title.
+    /// </summary>
+    /// <returns>The current LoginPage instance for fluent chaining.</returns>
+    public override LoginPage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
 
+        PageLogger.LogDebug("Performing LoginPage-specific validation (Page Title).");
         try
         {
             Wait.WaitForPageTitle(Driver, PageLogger, PageName, LoginPageMap.PageTitle);
-            PageLogger.LogInformation("Page title 'Swag Labs' verified for {PageName}.", PageName);
+            PageLogger.LogInformation("Page title '{PageTitle}' verified for {PageName}.", LoginPageMap.PageTitle, PageName);
         }
         catch (WebDriverTimeoutException ex)
         {
-            PageLogger.LogError(ex, "{PageName} did not load with the expected title 'Swag Labs'.", PageName);
+            PageLogger.LogError(ex, "{PageName} did not load with the expected title '{PageTitle}'.", PageName, LoginPageMap.PageTitle);
             throw;
         }
 
-        PageLogger.LogDebug("{PageName} instance fully created and validated.", PageName);
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
@@ -31,10 +31,27 @@ public class ShoppingCartPage : BasePage
     public ShoppingCartPage(IWebDriver driver, ILoggerFactory loggerFactory, ISettingsProviderService settingsProvider, IRetryService retryService)
         : base(driver, loggerFactory, settingsProvider, retryService)
     {
+        PageLogger.LogDebug("{PageName} instance created. Call AssertPageIsLoaded() to verify.", PageName);
+    }
+
+    /// <summary>
+    /// Asserts that the ShoppingCartPage is fully loaded by performing base checks and
+    /// verifying the page URL.
+    /// </summary>
+    /// <returns>The current ShoppingCartPage instance for fluent chaining.</returns>
+    public override ShoppingCartPage AssertPageIsLoaded()
+    {
+        _ = base.AssertPageIsLoaded();
+
+        PageLogger.LogDebug("Performing ShoppingCartPage-specific validation (URL check).");
+
         string expectedPath = ShoppingCartPageMap.PageUrlPath;
         Wait.Until(d => d.Url.Contains(expectedPath, StringComparison.OrdinalIgnoreCase))
             .ShouldBeTrue($"Expected URL to contain '{expectedPath}' but was '{Driver.Url}'.");
-        PageLogger.LogInformation("{PageName} loaded and URL verified.", PageName);
+
+        PageLogger.LogInformation("{PageName} URL verified.", PageName);
+
+        return this;
     }
 
     /// <summary>

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Checkout.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Checkout.cs
@@ -42,11 +42,6 @@ public partial class SauceDemoTests : BaseTest
         var checkoutStepOnePage = (CheckoutStepOnePage)shoppingCartPage.ClickCheckout();
         TestLogger.LogInformation("Navigated to Checkout Step One page.");
 
-        // --- Navigate to Cart and Proceed to Checkout ---
-        _ = inventoryPage.ClickShoppingCartLink().ShouldBeOfType<ShoppingCartPage>();
-        _ = (CheckoutStepOnePage)shoppingCartPage.ClickCheckout();
-        TestLogger.LogInformation("Navigated to Checkout Step One page.");
-
         // --- Fill Information and Continue ---
         var fillInfoTimer = new PerformanceTimer("TestStep_FillCheckoutStepOneInfo", TestLogger, resourceMonitor: ResourceMonitor);
         CheckoutStepTwoPage checkoutStepTwoPage;

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Helpers.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Helpers.cs
@@ -23,7 +23,9 @@ public partial class SauceDemoTests : BaseTest
             resourceMonitor: ResourceMonitor
         );
 
-        LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+        LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+            .AssertPageIsLoaded();
+
         BasePage resultPage = loginPage
             .EnterUsername(_sauceDemoSettings.LoginUsernameStandardUser)
             .EnterPassword(_sauceDemoSettings.LoginPassword)

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Inventory.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Inventory.cs
@@ -60,7 +60,8 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
 
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameStandardUser)
@@ -166,7 +167,9 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
+
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameProblemUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -303,7 +306,9 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
+
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernamePerformanceGlitchUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -399,7 +404,9 @@ public partial class SauceDemoTests : BaseTest
 
         try
         {
-            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
+
             resultPage = loginPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameErrorUser)
                 .EnterPassword(_sauceDemoSettings.LoginPassword)
@@ -573,7 +580,8 @@ public partial class SauceDemoTests : BaseTest
         try
         {
             TestLogger.LogDebug("Instantiating LoginPage for {TestName}.", currentTestName);
-            LoginPage loginPage = new(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage loginPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
 
             TestLogger.LogInformation(
                 "Attempting login with username: {LoginUsername} (visual_user) using Click action for {TestName}.",

--- a/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Login.cs
+++ b/SeleniumTraining/Tests/SauceDemoTests/SauceDemoTests.Login.cs
@@ -45,7 +45,8 @@ public partial class SauceDemoTests : BaseTest
         try
         {
             TestLogger.LogDebug("Instantiating LoginPage.");
-            var initialPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService);
+            LoginPage initialPage = new LoginPage(LifecycleManager.WebDriverManager.GetDriver(), PageObjectLoggerFactory, SettingsProvider, RetryService)
+                .AssertPageIsLoaded();
 
             loginPage = initialPage
                 .EnterUsername(_sauceDemoSettings.LoginUsernameLockedOutUser)


### PR DESCRIPTION
This refactoring removes page load validation from the constructors of all page objects and moves it into a new, chainable `AssertPageIsLoaded()` method.

Previously, page readiness was asserted implicitly upon object instantiation. This could obscure the root cause of test failures, attributing them to a `new PageObject()` line rather than a clear verification step.

By making the validation explicit:
- Test readability is improved by showing an intentional `AssertPageIsLoaded()` step.
- Debugging is easier, as failures now point directly to the verification call in the test log.
- The `AssertPageIsLoaded()` method is overridden in derived pages to include page-specific checks (like URL and Title), while leveraging covariant return types to maintain a fluent API.