### PR TITLE
feat(factories): enable specialization of user profile preferences

### DIFF
--- a/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/ChromeDriverFactoryService.cs
@@ -38,50 +38,7 @@ public class ChromeDriverFactoryService : ChromiumDriverFactoryServiceBase
         }
 
         ChromeOptions chromeOptions = ConfigureCommonChromiumOptions<ChromeOptions>(settings, options, out _);
-
-        if (settings.UserProfilePreferences != null && settings.UserProfilePreferences.Count != 0)
-        {
-            ServiceLogger.LogDebug(
-                "Applying {PrefCount} user profile preferences via 'prefs' experimental option.",
-                settings.UserProfilePreferences.Count
-            );
-
-            foreach (KeyValuePair<string, object> pref in settings.UserProfilePreferences)
-            {
-                try
-                {
-                    string key = pref.Key;
-                    string? stringValue = pref.Value?.ToString();
-
-                    if (stringValue is null)
-                    {
-                        ServiceLogger.LogWarning("Skipping user profile preference '{PrefKey}' because its value is null.", key);
-                        continue;
-                    }
-
-                    object finalValue;
-
-                    if (bool.TryParse(stringValue, out bool boolResult))
-                    {
-                        finalValue = boolResult;
-                    }
-                    else if (int.TryParse(stringValue, out int intResult))
-                    {
-                        finalValue = intResult;
-                    }
-                    else
-                    {
-                        finalValue = stringValue;
-                    }
-
-                    chromeOptions.AddUserProfilePreference(key, finalValue);
-                }
-                catch (Exception ex)
-                {
-                    ServiceLogger.LogError(ex, "Failed to apply user profile preference '{PrefKey}' with value '{PrefValue}'.", pref.Key, pref.Value);
-                }
-            }
-        }
+        ApplyUserProfilePreferences(chromeOptions, settings.UserProfilePreferences);
 
         string chromeExecutablePath = GetChromeExecutablePathInternal();
         if (!string.IsNullOrEmpty(chromeExecutablePath))

--- a/SeleniumTraining/Core/Services/Drivers/EdgeDriverFactoryService.cs
+++ b/SeleniumTraining/Core/Services/Drivers/EdgeDriverFactoryService.cs
@@ -37,50 +37,7 @@ public class EdgeDriverFactoryService : ChromiumDriverFactoryServiceBase
         }
 
         EdgeOptions edgeOptions = ConfigureCommonChromiumOptions<EdgeOptions>(settings, options, out _);
-
-        if (settings.UserProfilePreferences != null && settings.UserProfilePreferences.Count != 0)
-        {
-            ServiceLogger.LogDebug(
-                "Applying {PrefCount} user profile preferences via 'prefs' experimental option.",
-                settings.UserProfilePreferences.Count
-            );
-
-            foreach (KeyValuePair<string, object> pref in settings.UserProfilePreferences)
-            {
-                try
-                {
-                    string key = pref.Key;
-                    string? stringValue = pref.Value?.ToString();
-
-                    if (stringValue is null)
-                    {
-                        ServiceLogger.LogWarning("Skipping user profile preference '{PrefKey}' because its value is null.", key);
-                        continue;
-                    }
-
-                    object finalValue;
-
-                    if (bool.TryParse(stringValue, out bool boolResult))
-                    {
-                        finalValue = boolResult;
-                    }
-                    else if (int.TryParse(stringValue, out int intResult))
-                    {
-                        finalValue = intResult;
-                    }
-                    else
-                    {
-                        finalValue = stringValue;
-                    }
-
-                    edgeOptions.AddUserProfilePreference(key, finalValue);
-                }
-                catch (Exception ex)
-                {
-                    ServiceLogger.LogError(ex, "Failed to apply user profile preference '{PrefKey}' with value '{PrefValue}'.", pref.Key, pref.Value);
-                }
-            }
-        }
+        ApplyUserProfilePreferences(edgeOptions, settings.UserProfilePreferences);
 
         string edgeExecutablePath = GetEdgeExecutablePathInternal();
         if (!string.IsNullOrEmpty(edgeExecutablePath))


### PR DESCRIPTION
The protected `ApplyUserProfilePreferences` method in the `ChromiumDriverFactoryServiceBase` is now `virtual`.

This change improves the factory design by allowing derived classes like `ChromeDriverFactoryService` to `override` the preference application logic. It enables adding browser-specific preferences on top of the common ones, rather than being limited to the shared implementation.

This directly addresses the need for future flexibility without sacrificing the DRY principle.