### PR TITLE
ocs(Pages): update XML documentation after refactoring

### DIFF
--- a/SeleniumTraining/Pages/BasePage.cs
+++ b/SeleniumTraining/Pages/BasePage.cs
@@ -85,17 +85,18 @@ public abstract class BasePage
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BasePage"/> abstract class.
-    /// Sets up WebDriver, WebDriverWait, logging, settings, retry service, and performs
-    /// initial page load and critical element visibility checks.
+    /// Sets up WebDriver, WebDriverWait, logging, settings, and retry service.
+    /// Does NOT perform page load validation; call <see cref="AssertPageIsLoaded"/> for that purpose.
     /// </summary>
+    /// <remarks>
+    /// This constructor is responsible for initializing all the essential services and properties for the page object.
+    /// All page load and readiness checks have been moved to the <see cref="AssertPageIsLoaded"/> method
+    /// to make verification an explicit step in the test flow.
+    /// </remarks>
     /// <param name="driver">The <see cref="IWebDriver"/> instance for browser interaction. Must not be null.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating loggers. Must not be null.</param>
     /// <param name="settingsProvider">The <see cref="ISettingsProviderService"/> for accessing configurations. Must not be null.</param>
     /// <param name="retryService">The <see cref="IRetryService"/> for executing operations with retry logic. Must not be null.</param>
-    /// <param name="defaultTimeoutSeconds">The default timeout in seconds for the <see cref="WebDriverWait"/> instance. Defaults to 5 seconds.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="driver"/>, <paramref name="loggerFactory"/>, <paramref name="settingsProvider"/>, or <paramref name="retryService"/> is null.</exception>
-    /// <exception cref="WebDriverTimeoutException">Thrown if <see cref="WaitForPageLoad"/>, <see cref="EnsureCriticalElementsAreDisplayed"/>, or the additional readiness checks time out.</exception>
-    /// <exception cref="Exception">Thrown for other unexpected errors during initialization.</exception>
     protected BasePage(
         IWebDriver driver,
         ILoggerFactory loggerFactory,
@@ -127,6 +128,7 @@ public abstract class BasePage
     /// immediately after instantiating a page object.
     /// </summary>
     /// <returns>The current page instance for fluent chaining.</returns>
+    /// <exception cref="WebDriverTimeoutException">Thrown if the page or its critical elements do not load within the configured timeout.</exception>
     [AllureStep("Asserting that page '{PageName}' is loaded and ready")]
     public virtual BasePage AssertPageIsLoaded()
     {

--- a/SeleniumTraining/Pages/SauceDemo/LoginPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/LoginPage.cs
@@ -24,8 +24,7 @@ public class LoginPage : BasePage
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginPage"/> class.
-    /// It calls the base constructor and then performs LoginPage-specific initialization checks,
-    /// such as verifying the page title.
+    /// /// Call <see cref="AssertPageIsLoaded()"/> to perform validation after instantiation.
     /// </summary>
     /// <param name="driver">The <see cref="IWebDriver"/> instance for browser interaction. Passed to base.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating loggers. Passed to base.</param>

--- a/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
+++ b/SeleniumTraining/Pages/SauceDemo/ShoppingCartPage.cs
@@ -103,11 +103,7 @@ public class ShoppingCartPage : BasePage
     /// <summary>
     /// Clicks the "Checkout" button to proceed to the first step of the checkout process.
     /// </summary>
-    /// <returns>
-    /// This method should return an instance of the page object representing the first step of checkout (e.g., CheckoutStepOnePage).
-    /// Currently, it throws a <see cref="NotImplementedException"/> as the target page object is not yet implemented.
-    /// </returns>
-    /// <exception cref="NotImplementedException">Always thrown as the checkout page flow is not yet implemented beyond this point.</exception>
+    /// <returns>A new, validated <see cref="CheckoutStepOnePage"/> instance.</returns>
     [AllureStep("Click 'Checkout' button")]
     public BasePage ClickCheckout()
     {


### PR DESCRIPTION
Updates the XML documentation for the BasePage and all derived page objects to accurately reflect the new `AssertPageIsLoaded()` pattern.

- The BasePage constructor's summary now states that it no longer performs validation.
- The new `AssertPageIsLoaded()` methods are documented to explain their role.
- The `<returns>` tags for navigation methods are updated to specify that they return a validated page object.

This ensures the code comments are in sync with the new, more explicit page validation logic.